### PR TITLE
Add csv module to Glouton

### DIFF
--- a/modules/csv.py
+++ b/modules/csv.py
@@ -1,0 +1,21 @@
+from modules.moduleBase import ModuleBase
+from time import strftime, strptime
+from datetime import datetime
+
+# This module writes out decoded telemetry frames in the same format
+# provided by the telemetry download option on db.satnogs.org.
+class CSV(ModuleBase):
+
+    def runAfterDownload(self, file_name, full_path, observation):
+        csv_file = full_path + '/' + file_name + '.csv'
+
+        # FIXME: The date format appears to be RFC 3339; haven't found
+        # a better way of parsing this than this format string, which
+        # assumes that it'll end in Z.
+        dobj = datetime.strptime(observation['start'], '%Y-%m-%dT%H:%M:%SZ')
+        obs_time = dobj.strftime('%Y-%m-%d %H:%M:%S')
+
+        with open(full_path + '/' + file_name, 'rb') as f:
+            hexdump = f.read().hex().upper()
+        with open(csv_file, 'w') as f:
+            f.write(obs_time + '|' + hexdump + '\n')


### PR DESCRIPTION
This PR adds a new module, `csv.py`.  It is intended to write out demodulated data frames using the same  format as the telemetry download option on db.satnogs.org:  date plus frame in hexdump format, with `|` as the separator.  

This module was developed for the [Polaris](https://gitlab.com/crespum/polaris) project, which aims to apply machine learning techniques to satellite telemetry gathered by the SatNOGS project.  You can read a bit more about the project [here](https://community.libre.space/t/decentralised-open-source-rocketry-a-roadmap/3116/7).

Here's an example of using the module to download data for the [Elfin-A](https://db.satnogs.org/satellite/43617/) satellite:

```
06:27 $ python ./glouton.py --norad 43617 -s 2019-01-05T11:00:00 -e 2019-01-05T12:00:00  --demoddata --demodm CSV
                   .-'''-.                     .-'''-.                
          .---.   '   _    \                  '   _    \              
          |   | /   /` '.   \               /   /` '.   \    _..._    
  .--./)  |   |.   |     \  '              .   |     \  '  .'     '.  
 /.''\   |   ||   '      |  '          .| |   '      |  '.   .-.   . 
| |  | |  |   |\    \     / /         .' |_\    \     / / |  '   '  | 
 \`-' /   |   | `.   ` ..' /_    _  .'     |`.   ` ..' /  |  |   |  | 
 /("'`    |   |    '-...-'`| '  / |'--.  .-'   '-...-'`   |  |   |  | 
 \ '---.  |   |           .' | .' |   |  |                |  |   |  | 
  /'""'.\ |   |           /  | /  |   |  |                |  |   |  | 
 ||     ||'---'          |   `'.  |   |  '.'              |  |   |  | 
 '. __//                '   .'|  '/  |   /               |  |   |  | 
  `'---'                  `-'  `--'   `'-'                '--'   '--' 
	SATNOGS DATA DOWNLOADER
	-----------------------

Demoddata module(s) loading :
module : CSV loaded
scanning page...1

downloading started (Ctrl + C to stop)...	~(  ^o^)~
downloading...data_393542_2019-01-05T11-28-09
no demoddata found for the observation 397242 of 2019-01-05T11:17:49Z
no demoddata found for the observation 395372 of 2019-01-05T11:17:29Z
no demoddata found for the observation 395660 of 2019-01-05T11:16:12Z
no demoddata found for the observation 396495 of 2019-01-05T11:13:15Z


all jobs are finished	(   ^ o^)\m/
(venv) ✔ ~/dev/glouton-satnogs-data-downloader [csv|…5] 
06:28 $ ls -l demoddata__01-05-2019T11-00-00__01-05-2019T12-00-00
total 8
-rw-rw-r--. 1 aardvark aardvark 270 Jan 25 06:28 data_393542_2019-01-05T11-28-09
-rw-rw-r--. 1 aardvark aardvark 561 Jan 25 06:28 data_393542_2019-01-05T11-28-09.csv
(venv) ✔ ~/dev/glouton-satnogs-data-downloader [csv|…5] 
06:28 $ cat demoddata__01-05-2019T11-00-00__01-05-2019T12-00-00/data_393542_2019-01-05T11-28-09.csv
2019-01-05 11:18:14|AE6CB2A4827260AE9464B09CB0E103F0930E8770001901051125460000000000000000000000000000000000000000000000000000000000000000000000000000000000000008FD80048004A0032000000000190105112548015B01E801D8000202B802FD03040307020B0000001C00A20B00660000E5194A04730B2065C0047A17C300080430069007C0000014141212190105112307FF9100450025FF54FFCC000E1080FC000D80FE00190105112342002600D200300000FFC400B51080FC000D00FE001800B803B400EF3B4661003A3C05B1F800090F111700624E4800001090009105110727270B051110300B051113300B051113350B051116390B051119410B051122450B656C6661785E
(venv) ✔ ~/dev/glouton-satnogs-data-downloader [csv|…5] 
06:28 $ 
```

I'm not sure if you want a note about the module's purpose added to the README -- let me know if I should add that, or if you have any questions.

Thanks kindly!

Signed-off-by: Hugh Brown (Saint Aardvark the Carpeted) <aardvark@saintaardvarkthecarpeted.com>